### PR TITLE
fix(read-posts): 优化帖子阅读逻辑和错误处理

### DIFF
--- a/linuxdo_read_posts.py
+++ b/linuxdo_read_posts.py
@@ -217,7 +217,7 @@ class LinuxDoReadPosts:
         except IOError as e:
             print(f"⚠️ {self.username}: Failed to save topic ID: {e}")
 
-    async def _read_posts(self, page, base_topic_id: int, max_posts: int) -> int:
+    async def _read_posts(self, page, base_topic_id: int, max_posts: int) -> tuple[int, int]:
         """浏览帖子
 
         从 base_topic_id 开始，随机向上加 1-5 打开链接，
@@ -229,7 +229,7 @@ class LinuxDoReadPosts:
             max_posts: 最大浏览帖子数
 
         Returns:
-            最后浏览的帖子ID
+            (最后浏览的帖子ID, 实际阅读数量)
         """
 
         # 从缓存文件读取上次的 topic_id
@@ -315,7 +315,7 @@ class LinuxDoReadPosts:
         # 保存当前 topic_id 到缓存
         self._save_topic_id(current_topic_id)
 
-        return current_topic_id
+        return current_topic_id, read_count
 
     async def _scroll_to_read(self, page) -> None:
         """自动滚动浏览帖子内容
@@ -417,11 +417,11 @@ class LinuxDoReadPosts:
 
                 # 浏览帖子
                 print(f"ℹ️ {self.username}: Starting to read posts...")
-                last_topic_id = await self._read_posts(page, base_topic_id, max_posts)
+                last_topic_id, read_count = await self._read_posts(page, base_topic_id, max_posts)
 
-                print(f"✅ {self.username}: Successfully read {max_posts} posts")
+                print(f"✅ {self.username}: Successfully read {read_count} posts")
                 return True, {
-                    "read_count": max_posts,
+                    "read_count": read_count,
                     "last_topic_id": last_topic_id,
                 }
 


### PR DESCRIPTION
- 增加连续无效帖子跳过机制，避免卡在无效ID段
- 使用innerText替代innerHTML解析页面进度信息
- 添加页数解析校验，确保数据有效性
- 实现无效帖子计数器，提升爬取稳定性
- 修复进度信息解析逻辑，增强健壮性
- 修改 _read_posts 方法返回类型为 tuple，包含最后浏览的帖子ID和实际阅读数量
- 更新方法注释和返回值说明
- 调整调用处代码以处理新的返回值结构
- 使用实际阅读数量替换固定的最大帖子数进行日志输出和结果返回