### PR TITLE
fix(checkin): 修复回调 URL 参数编码问题

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -1107,7 +1107,7 @@ class CheckIn:
 
                 # 构建带参数的回调 URL
                 base_url = self.provider_config.get_github_auth_url()
-                callback_url = f"{base_url}?{urlencode(result_data)}"
+                callback_url = f"{base_url}?{urlencode(result_data, doseq=True)}"
                 print(f"ℹ️ {self.account_name}: Callback URL: {callback_url}")
                 try:
                     # 将 Camoufox 格式的 cookies 转换为 curl_cffi 格式
@@ -1270,7 +1270,7 @@ class CheckIn:
 
                 # 构建带参数的回调 URL
                 base_url = self.provider_config.get_linuxdo_auth_url()
-                callback_url = f"{base_url}?{urlencode(result_data)}"
+                callback_url = f"{base_url}?{urlencode(result_data, doseq=True)}"
                 print(f"ℹ️ {self.account_name}: Callback URL: {callback_url}")
                 try:
                     # 将 Camoufox 格式的 cookies 转换为 curl_cffi 格式


### PR DESCRIPTION
- 在 urlencode 中添加 doseq=True 参数以正确处理序列化数据
- 确保回调 URL 能够正确传递所有查询参数