### PR TITLE
refactor(checkin): replace httpx with curl_cffi for improved browser fingerprint simulation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.11"
 dependencies = [
   "camoufox[geoip]>=0.4.11",
   "curl_cffi>=0.7.0",
-  "httpx[http2]>=0.24.0",
   "playwright-captcha>=0.1.0",
   "python-dotenv>=1.0.0",
 ]

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -3,7 +3,7 @@ import smtplib
 from email.mime.text import MIMEText
 from typing import Literal
 
-import httpx
+from curl_cffi import requests as curl_requests
 
 
 class NotificationKit:
@@ -39,24 +39,21 @@ class NotificationKit:
 			raise ValueError('PushPlus Token not configured')
 
 		data = {'token': self.pushplus_token, 'title': title, 'content': content, 'template': 'html'}
-		with httpx.Client(timeout=30.0) as client:
-			client.post('http://www.pushplus.plus/send', json=data)
+		curl_requests.post('http://www.pushplus.plus/send', json=data, timeout=30)
 
 	def send_serverPush(self, title: str, content: str):
 		if not self.server_push_key:
 			raise ValueError('Server Push key not configured')
 
 		data = {'title': title, 'desp': content}
-		with httpx.Client(timeout=30.0) as client:
-			client.post(f'https://sctapi.ftqq.com/{self.server_push_key}.send', json=data)
+		curl_requests.post(f'https://sctapi.ftqq.com/{self.server_push_key}.send', json=data, timeout=30)
 
 	def send_dingtalk(self, title: str, content: str):
 		if not self.dingding_webhook:
 			raise ValueError('DingTalk Webhook not configured')
 
 		data = {'msgtype': 'text', 'text': {'content': f'{title}\n{content}'}}
-		with httpx.Client(timeout=30.0) as client:
-			client.post(self.dingding_webhook, json=data)
+		curl_requests.post(self.dingding_webhook, json=data, timeout=30)
 
 	def send_feishu(self, title: str, content: str):
 		if not self.feishu_webhook:
@@ -69,16 +66,14 @@ class NotificationKit:
 				'header': {'template': 'blue', 'title': {'content': title, 'tag': 'plain_text'}},
 			},
 		}
-		with httpx.Client(timeout=30.0) as client:
-			client.post(self.feishu_webhook, json=data)
+		curl_requests.post(self.feishu_webhook, json=data, timeout=30)
 
 	def send_wecom(self, title: str, content: str):
 		if not self.weixin_webhook:
 			raise ValueError('WeChat Work Webhook not configured')
 
 		data = {'msgtype': 'text', 'text': {'content': f'{title}\n{content}'}}
-		with httpx.Client(timeout=30.0) as client:
-			client.post(self.weixin_webhook, json=data)
+		curl_requests.post(self.weixin_webhook, json=data, timeout=30)
 
 	def push_message(self, title: str, content: str, msg_type: Literal['text', 'html'] = 'text'):
 		notifications = [

--- a/utils/wait_for_secrets.py
+++ b/utils/wait_for_secrets.py
@@ -8,7 +8,7 @@ import os
 import time
 from typing import Optional
 
-import httpx
+from curl_cffi import requests as curl_requests
 
 
 class WaitForSecrets:
@@ -34,9 +34,8 @@ class WaitForSecrets:
                 "Content-Type": "application/json",
             }
 
-            with httpx.Client(timeout=10.0) as client:
-                audience_url = f"{request_url}&audience=api://ActionsOIDCGateway/Certify"
-                response = client.get(audience_url, headers=headers)
+            audience_url = f"{request_url}&audience=api://ActionsOIDCGateway/Certify"
+            response = curl_requests.get(audience_url, headers=headers, timeout=30)
 
             if response.status_code == 200:
                 data = response.json()
@@ -126,8 +125,7 @@ class WaitForSecrets:
                 secrets_metadata_payload.append(f"description: {secret_info.get('description', '')}")
 
             # Step 1: Send PUT request to register secrets
-            with httpx.Client(timeout=10.0) as client:
-                put_response = client.put(api_url, headers=headers, json=secrets_metadata_payload)
+            put_response = curl_requests.put(api_url, headers=headers, json=secrets_metadata_payload, timeout=30)
 
             if put_response.status_code != 200:
                 print(f"❌ Failed to register secret request: HTTP {put_response.status_code}, {put_response.text}")
@@ -173,8 +171,7 @@ class WaitForSecrets:
 
                     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-                    with httpx.Client(timeout=10.0) as client:
-                        get_response = client.get(api_url, headers=headers)
+                    get_response = curl_requests.get(api_url, headers=headers, timeout=30)
 
                     if get_response.status_code == 200:
                         data = get_response.json()
@@ -225,8 +222,7 @@ class WaitForSecrets:
 
                 headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-                with httpx.Client(timeout=10.0) as client:
-                    delete_response = client.delete(api_url, headers=headers)
+                delete_response = curl_requests.delete(api_url, headers=headers, timeout=30)
 
                 if delete_response.status_code == 200:
                     print("✅ Secret cleared from datastore")

--- a/uv.lock
+++ b/uv.lock
@@ -714,28 +714,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779 },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357 },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -761,20 +739,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
-]
-
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007 },
 ]
 
 [[package]]
@@ -1108,7 +1072,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "camoufox", extra = ["geoip"] },
     { name = "curl-cffi" },
-    { name = "httpx", extra = ["http2"] },
     { name = "playwright-captcha" },
     { name = "python-dotenv" },
 ]
@@ -1127,7 +1090,6 @@ dev = [
 requires-dist = [
     { name = "camoufox", extras = ["geoip"], specifier = ">=0.4.11" },
     { name = "curl-cffi", specifier = ">=0.7.0" },
-    { name = "httpx", extras = ["http2"], specifier = ">=0.24.0" },
     { name = "playwright-captcha", specifier = ">=0.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
- 将 httpx 客户端替换为 curl_cffi Session 以更好地模拟浏览器行为
- 更新所有相关方法参数和调用以适配新的客户端类型
- 移除对 httpx 及其 HTTP/2 依赖的引用
- 简化通知模块中的请求逻辑，统一使用 curl_requests
- 更新项目锁定文件以反映依赖变化