### PR TITLE
feat: add free-duckcoding provider configuration

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -635,6 +635,25 @@ class AppConfig:
                 aliyun_captcha=False,
                 bypass_method=None,
             ),
+            "free-duckcoding": ProviderConfig(
+                name="free-duckcoding",
+                origin="https://free.duckcoding.com",
+                login_path="/login",
+                status_path="/api/status",
+                auth_state_path="/api/oauth/state",
+                check_in_path="/api/user/checkin",
+                check_in_status=True,
+                user_info_path="/api/user/self",
+                topup_path="/api/user/topup",
+                get_cdk=None,
+                api_user_key="new-api-user",
+                github_client_id=None,
+                github_auth_path="/api/oauth/github",
+                linuxdo_client_id="XNJfOdoSeXkcx80mDydoheJ0nZS4tjIf",
+                linuxdo_auth_path="/api/oauth/linuxdo",
+                aliyun_captcha=False,
+                bypass_method=None,
+            ),
         }
 
         # 尝试从环境变量加载自定义 providers


### PR DESCRIPTION
 Add support for `free.duckcoding.com` check-in provider.