### PR TITLE
Load dotenv before notify init

### DIFF
--- a/checkin_996/main.py
+++ b/checkin_996/main.py
@@ -17,10 +17,10 @@ from checkin import CheckIn
 # Add parent directory to Python path to find utils module
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+load_dotenv(override=True)
+
 from utils.notify import notify
 from utils.balance_hash import load_balance_hash, save_balance_hash
-
-load_dotenv(override=True)
 
 CHECKIN_HASH_FILE = "balance_hash_996.txt"
 

--- a/linuxdo_read_posts.py
+++ b/linuxdo_read_posts.py
@@ -11,6 +11,9 @@ import sys
 import random
 from datetime import datetime
 from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
 from camoufox.async_api import AsyncCamoufox
 from utils.browser_utils import take_screenshot, save_page_content_to_file
 from utils.notify import notify
@@ -458,7 +461,6 @@ def load_linuxdo_accounts() -> list[dict]:
 
 async def main():
     """主函数"""
-    load_dotenv(override=True)
 
     print("🚀 Linux.do read posts script started")
     print(f'🕒 Execution time: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')

--- a/main.py
+++ b/main.py
@@ -9,12 +9,13 @@ import json
 import sys
 from datetime import datetime
 from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
 from utils.config import AppConfig
 from utils.notify import notify
 from utils.balance_hash import load_balance_hash, save_balance_hash
 from checkin import CheckIn
-
-load_dotenv(override=True)
 
 BALANCE_HASH_FILE = "balance_hash.txt"
 


### PR DESCRIPTION
问题
  - 当只在 .env 配置 FEISHU_WEBHOOK / DINGDING_WEBHOOK / WEIXIN_WEBHOOK 等通知变量时，通知经常不生效。

  原因
  - main.py / checkin_996/main.py / linuxdo_read_posts.py 里先 import notify，再 load_dotenv()。
  - NotificationKit 在 import 时就读取环境变量，导致 .env 尚未加载时取到空值。

  修复
  - 将 load_dotenv(override=True) 提前到导入 notify 之前，保证通知初始化时能读到 .env。

  影响范围
  - main.py
  - checkin_996/main.py
  - linuxdo_read_posts.py

  测试
  - 在生产环境通过 systemd 运行后，飞书通知成功发送（已验证）。