### PR TITLE
feat: add site password login method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Affs:
 - ✅ 多种机器人通知（可选）
 - ✅ linux.do 登录认证
 - ✅ github 登录认证 (with OTP)
+- ✅ 站点账号密码登录认证
 - ✅ Cloudflare bypass
 
 ## 使用方法
@@ -85,10 +86,10 @@ Affs:
 
 ### 3 多账号配置格式
 > 如果未提供 `name` 字段，会使用 `{provider.name} 1`、`{provider.name} 2` 等默认名称。  
-> 配置中 `cookies`、`github`、`linux.do` 必须至少配置 1 个。  
+> 配置中 `cookies`、`github`、`linux.do`、`site` 必须至少配置 1 个。  
 > 使用 `cookies` 设置时，`api_user` 字段必填。  
 
-#### 3.1 OAuth 配置支持三种格式
+#### 3.1 登录配置格式
 
 `github` 和 `linux.do` 字段支持以下三种配置格式：
 
@@ -111,6 +112,21 @@ Affs:
 ]}
 ```
 
+`site` 字段支持以下两种配置格式：
+
+**1. dict 类型 - 单个站点账号**
+```json
+{"provider": "anyrouter", "site": {"username": "站点用户名", "password": "站点密码"}}
+```
+
+**2. array 类型 - 多个站点账号**
+```json
+{"provider": "anyrouter", "site": [
+  {"username": "用户名1", "password": "密码1"},
+  {"username": "用户名2", "password": "密码2", "mode": "browser"}
+]}
+```
+
 #### 3.2 完整示例
 
 ```json
@@ -128,6 +144,10 @@ Affs:
       "linux.do": {
         "username": "myuser",
         "password": "mypass"
+      },
+      "site": {
+        "username": "site-user",
+        "password": "site-pass"
       },
       // --- 额外的配置说明 ---
       // 当前账号使用代理
@@ -175,6 +195,19 @@ Affs:
   - `true`：使用 `GITHUB_ACCOUNTS` 中的全局账号
   - `{"username": "xxx", "password": "xxx"}`：单个账号
   - `[{"username": "xxx", "password": "xxx"}, ...]`：多个账号
+- `site`(可选)：用于站点账号密码登录，支持两种格式：
+  - `{"username": "xxx", "password": "xxx"}`：单个账号
+  - `[{"username": "xxx", "password": "xxx"}, ...]`：多个账号
+  - `mode` 可选值：`auto`、`api`、`browser`，默认 `auto`
+
+#### 3.3.1 `site` 登录说明
+
+- `mode=api`：直接请求站点登录接口：`/api/user/login?turnstile=`。
+- `mode=browser`：使用内置浏览器打开登录页，切换到“邮箱或用户名登录”，填写账号密码并提交。
+- `mode=auto`：先尝试 `api` 登录，失败后自动回退到 `browser` 登录。
+- 登录成功后会自动读取响应或浏览器中的 cookie，并使用响应中的 `data.id` 或页面本地存储/用户信息接口中的用户 ID 作为 `api_user`。
+- 因此使用 `site` 登录时，不需要手动填写 `cookies.session` 和 `api_user`。
+- 如果目标站点启用了额外验证码、前端校验或防护，优先使用 `mode=auto` 或 `mode=browser`。
 
 #### 3.4 供应商配置：
 

--- a/checkin.py
+++ b/checkin.py
@@ -14,11 +14,11 @@ from urllib.parse import urlparse, urlencode
 from curl_cffi import requests as curl_requests
 from camoufox.async_api import AsyncCamoufox
 from utils.config import AccountConfig, ProviderConfig
-from utils.browser_utils import parse_cookies, get_random_user_agent, take_screenshot, aliyun_captcha_check
+from utils.browser_utils import parse_cookies, filter_cookies, get_random_user_agent, take_screenshot, aliyun_captcha_check
 from utils.get_cf_clearance import get_cf_clearance
 from utils.http_utils import proxy_resolve, response_resolve
 from utils.topup import topup
-from utils.get_headers import get_curl_cffi_impersonate
+from utils.get_headers import get_browser_headers, get_curl_cffi_impersonate, print_browser_headers
 from utils.mask_utils import mask_username
 
 class CheckIn:
@@ -1355,6 +1355,372 @@ class CheckIn:
         finally:
             session.close()
 
+    async def check_in_with_site(
+        self,
+        username: str,
+        password: str,
+        bypass_cookies: dict,
+        common_headers: dict,
+        mode: str = "auto",
+    ) -> tuple[bool, dict]:
+        """使用站点账号密码执行签到操作"""
+        print(
+            f"ℹ️ {self.account_name}: Executing check-in with site account, mode={mode} (using proxy: {'true' if self.http_proxy_config else 'false'})"
+        )
+
+        if mode == "browser":
+            return await self.check_in_with_site_browser(username, password, bypass_cookies, common_headers)
+
+        success, result = await self.check_in_with_site_api(username, password, bypass_cookies, common_headers)
+        if success or mode == "api":
+            return success, result
+
+        print(f"⚠️ {self.account_name}: Site API login failed, falling back to browser login")
+        return await self.check_in_with_site_browser(username, password, bypass_cookies, common_headers)
+
+    async def check_in_with_site_api(
+        self,
+        username: str,
+        password: str,
+        bypass_cookies: dict,
+        common_headers: dict,
+    ) -> tuple[bool, dict]:
+        """使用站点登录接口执行签到操作"""
+        print(
+            f"ℹ️ {self.account_name}: Executing site API login (using proxy: {'true' if self.http_proxy_config else 'false'})"
+        )
+
+        user_agent = common_headers.get("User-Agent", "")
+        impersonate = get_curl_cffi_impersonate(user_agent)
+
+        session = curl_requests.Session(impersonate=impersonate, proxy=self.http_proxy_config, timeout=30)
+        if impersonate:
+            print(f"ℹ️ {self.account_name}: Using curl_cffi Session with impersonate={impersonate}")
+
+        try:
+            session.cookies.update(bypass_cookies)
+
+            headers = common_headers.copy()
+            headers["Content-Type"] = "application/json"
+            headers["X-Requested-With"] = "XMLHttpRequest"
+            headers[self.provider_config.api_user_key] = "-1"
+            headers["Referer"] = self.provider_config.get_login_url()
+            headers["Origin"] = self.provider_config.origin
+
+            login_url = f"{self.provider_config.origin}/api/user/login?turnstile="
+            payload = {"username": username, "password": password}
+            response = session.post(login_url, headers=headers, json=payload, timeout=30)
+
+            if response.status_code != 200:
+                print(f"❌ {self.account_name}: Site login failed - HTTP {response.status_code}")
+                return False, {"error": f"Site login HTTP {response.status_code}"}
+
+            json_data = response_resolve(response, "site_login", self.account_name)
+            if json_data is None:
+                return False, {"error": "Site login returned invalid response"}
+
+            if not json_data.get("success"):
+                error_msg = json_data.get("message", "Site login failed")
+                print(f"❌ {self.account_name}: Site login failed - {error_msg}")
+                return False, {"error": error_msg}
+
+            user_data = json_data.get("data", {})
+            api_user = user_data.get("id")
+            if api_user is None:
+                print(f"❌ {self.account_name}: No user ID in site login response")
+                return False, {"error": "No user ID in site login response"}
+
+            user_cookies = {}
+            for cookie in session.cookies.jar:
+                user_cookies[cookie.name] = cookie.value
+
+            print(f"ℹ️ {self.account_name}: Extracted {len(user_cookies)} site login cookies: {list(user_cookies.keys())}")
+
+            merged_cookies = {**bypass_cookies, **user_cookies}
+            return await self.check_in_with_cookies(merged_cookies, common_headers, api_user, impersonate)
+
+        except Exception as e:
+            print(f"❌ {self.account_name}: Error occurred during site login process - {e}")
+            return False, {"error": "Site login process error"}
+        finally:
+            session.close()
+
+    async def _click_site_password_login_switch(self, page) -> bool:
+        """切换到站点账号密码登录表单，尽量使用稳定选择器和文本匹配。"""
+        selectors = [
+            'button:has-text("使用 邮箱或用户名 登录")',
+            'button:has-text("邮箱或用户名")',
+            'button:has-text("用户名")',
+            'button.semi-button:nth-child(4)',
+        ]
+
+        for selector in selectors:
+            try:
+                element = await page.query_selector(selector)
+                if element:
+                    print(f"ℹ️ {self.account_name}: Clicking site password-login switch by selector: {selector}")
+                    await element.click()
+                    await page.wait_for_timeout(1000)
+                    return True
+            except Exception as e:
+                print(f"⚠️ {self.account_name}: Failed password-login switch selector {selector}: {e}")
+
+        try:
+            clicked = await page.evaluate(
+                """() => {
+                    const candidates = Array.from(document.querySelectorAll('button'));
+                    const button = candidates.find((item) => {
+                        const text = (item.innerText || item.textContent || '').replace(/\s+/g, ' ').trim();
+                        return text.includes('邮箱或用户名') || text.includes('用户名') || text.includes('密码登录');
+                    });
+                    if (button) {
+                        button.click();
+                        return true;
+                    }
+                    return false;
+                }"""
+            )
+            if clicked:
+                print(f"ℹ️ {self.account_name}: Clicking site password-login switch by text scan")
+                await page.wait_for_timeout(1000)
+                return True
+        except Exception as e:
+            print(f"⚠️ {self.account_name}: Failed password-login switch text scan: {e}")
+
+        return False
+
+    async def _fill_site_login_form(self, page, username: str, password: str) -> bool:
+        """填写站点登录表单，使用 fill + 事件触发，兼容前端校验。"""
+        username_selectors = [
+            '#username',
+            'input[name="username"]',
+            'input[placeholder*="用户名"]',
+            'input[placeholder*="邮箱"]',
+            'input[type="text"]',
+        ]
+        password_selectors = [
+            '#password',
+            'input[name="password"]',
+            'input[type="password"]',
+        ]
+
+        username_selector = None
+        for selector in username_selectors:
+            try:
+                await page.wait_for_selector(selector, timeout=3000)
+                username_selector = selector
+                break
+            except Exception:
+                continue
+
+        password_selector = None
+        for selector in password_selectors:
+            try:
+                await page.wait_for_selector(selector, timeout=3000)
+                password_selector = selector
+                break
+            except Exception:
+                continue
+
+        if not username_selector or not password_selector:
+            print(f"❌ {self.account_name}: Site login form inputs not found")
+            return False
+
+        await page.fill(username_selector, username)
+        await page.dispatch_event(username_selector, "input")
+        await page.dispatch_event(username_selector, "change")
+        await page.wait_for_timeout(500)
+
+        await page.fill(password_selector, password)
+        await page.dispatch_event(password_selector, "input")
+        await page.dispatch_event(password_selector, "change")
+        await page.wait_for_timeout(500)
+        return True
+
+    async def _submit_site_login_form(self, page) -> bool:
+        """提交站点登录表单，优先使用表单内 submit 按钮。"""
+        selectors = [
+            'form button[type="submit"]',
+            'button[type="submit"]:has-text("继续")',
+            'button.semi-button-primary:has-text("继续")',
+            'button.semi-button-primary',
+        ]
+
+        for selector in selectors:
+            try:
+                element = await page.query_selector(selector)
+                if element:
+                    print(f"ℹ️ {self.account_name}: Submitting site login form by selector: {selector}")
+                    await element.click()
+                    return True
+            except Exception as e:
+                print(f"⚠️ {self.account_name}: Failed submit selector {selector}: {e}")
+
+        try:
+            submitted = await page.evaluate(
+                """() => {
+                    const buttons = Array.from(document.querySelectorAll('button'));
+                    const button = buttons.find((item) => {
+                        const text = (item.innerText || item.textContent || '').replace(/\s+/g, ' ').trim();
+                        return text.includes('继续') || text.includes('登录') || text.includes('登入');
+                    });
+                    if (button) {
+                        button.click();
+                        return true;
+                    }
+                    const form = document.querySelector('form');
+                    if (form) {
+                        form.requestSubmit ? form.requestSubmit() : form.submit();
+                        return true;
+                    }
+                    return false;
+                }"""
+            )
+            if submitted:
+                print(f"ℹ️ {self.account_name}: Submitting site login form by text/form scan")
+                return True
+        except Exception as e:
+            print(f"⚠️ {self.account_name}: Failed submit text/form scan: {e}")
+
+        return False
+
+    async def _read_site_api_user_from_browser(self, page, cookies: dict, common_headers: dict) -> str | int | None:
+        """从浏览器 localStorage 或 /api/user/self 获取用户 ID。"""
+        try:
+            user_data = await page.evaluate("() => localStorage.getItem('user')")
+            if user_data:
+                user_obj = json.loads(user_data)
+                api_user = user_obj.get("id")
+                if api_user is not None:
+                    print(f"✅ {self.account_name}: Got api user from localStorage: {api_user}")
+                    return api_user
+        except Exception as e:
+            print(f"⚠️ {self.account_name}: Error reading user from localStorage: {e}")
+
+        session = None
+        try:
+            user_agent = common_headers.get("User-Agent", "")
+            impersonate = get_curl_cffi_impersonate(user_agent)
+            session = curl_requests.Session(impersonate=impersonate, proxy=self.http_proxy_config, timeout=30)
+            session.cookies.update(cookies)
+
+            headers = common_headers.copy()
+            headers[self.provider_config.api_user_key] = "-1"
+            headers["Referer"] = self.provider_config.origin
+            headers["Origin"] = self.provider_config.origin
+
+            response = session.get(self.provider_config.get_user_info_url(), headers=headers, timeout=30)
+            if response.status_code == 200:
+                json_data = response_resolve(response, "site_user_self", self.account_name)
+                if json_data and json_data.get("success"):
+                    user_data = json_data.get("data", {})
+                    api_user = user_data.get("id")
+                    if api_user is not None:
+                        print(f"✅ {self.account_name}: Got api user from user-info API: {api_user}")
+                        return api_user
+            print(f"⚠️ {self.account_name}: Unable to get api user from user-info API, HTTP {response.status_code}")
+        except Exception as e:
+            print(f"⚠️ {self.account_name}: Error getting api user from user-info API: {e}")
+        finally:
+            if session:
+                session.close()
+
+        return None
+
+    async def check_in_with_site_browser(
+        self,
+        username: str,
+        password: str,
+        bypass_cookies: dict,
+        common_headers: dict,
+    ) -> tuple[bool, dict]:
+        """使用浏览器打开登录页并完成站点账号密码登录。"""
+        print(
+            f"ℹ️ {self.account_name}: Executing site browser login (using proxy: {'true' if self.camoufox_proxy_config else 'false'})"
+        )
+
+        async with AsyncCamoufox(
+            headless=False,
+            humanize=True,
+            locale="en-US",
+            geoip=True if self.camoufox_proxy_config else False,
+            proxy=self.camoufox_proxy_config,
+            os="macos",
+            config={
+                "forceScopeAccess": True,
+            },
+        ) as browser:
+            context = await browser.new_context()
+            if bypass_cookies:
+                parsed_origin = urlparse(self.provider_config.origin)
+                await context.add_cookies([
+                    {
+                        "name": name,
+                        "value": value,
+                        "domain": parsed_origin.hostname,
+                        "path": "/",
+                        "secure": parsed_origin.scheme == "https",
+                    }
+                    for name, value in bypass_cookies.items()
+                ])
+                print(f"ℹ️ {self.account_name}: Set {len(bypass_cookies)} bypass cookies before browser login")
+
+            page = await context.new_page()
+            try:
+                await page.goto(self.provider_config.get_login_url(), wait_until="domcontentloaded")
+                try:
+                    await page.wait_for_load_state("networkidle", timeout=10000)
+                except Exception:
+                    await page.wait_for_timeout(3000)
+
+                if self.provider_config.aliyun_captcha:
+                    await aliyun_captcha_check(page, self.account_name)
+
+                await self._click_site_password_login_switch(page)
+
+                if not await self._fill_site_login_form(page, username, password):
+                    await take_screenshot(page, "site_login_form_not_found", self.account_name)
+                    return False, {"error": "Site browser login form not found"}
+
+                current_url = page.url
+                if not await self._submit_site_login_form(page):
+                    await take_screenshot(page, "site_login_submit_not_found", self.account_name)
+                    return False, {"error": "Site browser login submit not found"}
+
+                try:
+                    await page.wait_for_function('localStorage.getItem("user") !== null', timeout=15000)
+                except Exception:
+                    try:
+                        await page.wait_for_url(lambda url: url != current_url, timeout=15000)
+                    except Exception:
+                        await page.wait_for_timeout(5000)
+
+                restore_cookies = await context.cookies()
+                user_cookies = filter_cookies(restore_cookies, self.provider_config.origin)
+                merged_cookies = {**bypass_cookies, **user_cookies}
+
+                api_user = await self._read_site_api_user_from_browser(page, merged_cookies, common_headers)
+                if api_user is None:
+                    await take_screenshot(page, "site_browser_login_no_user_id", self.account_name)
+                    return False, {"error": "Site browser login succeeded but no user ID found"}
+
+                browser_headers = await get_browser_headers(page)
+                updated_headers = common_headers.copy()
+                if browser_headers:
+                    print_browser_headers(self.account_name, browser_headers)
+                    updated_headers.update(browser_headers)
+
+                impersonate = get_curl_cffi_impersonate(updated_headers.get("User-Agent", ""))
+                return await self.check_in_with_cookies(merged_cookies, updated_headers, api_user, impersonate)
+
+            except Exception as e:
+                print(f"❌ {self.account_name}: Error occurred during site browser login process - {e}")
+                await take_screenshot(page, "site_browser_login_error", self.account_name)
+                return False, {"error": "Site browser login process error"}
+            finally:
+                await page.close()
+                await context.close()
+
     async def execute(self) -> list[tuple[str, bool, dict | None]]:
         """为单个账号执行签到操作，支持多种认证方式"""
         print(f"\n\n⏳ Starting to process {self.account_name}")
@@ -1447,6 +1813,7 @@ class CheckIn:
         cookies_data = self.account_config.cookies
         github_accounts = self.account_config.github  # 现在是 List[OAuthAccountConfig] 类型
         linuxdo_accounts = self.account_config.linux_do  # 现在是 List[OAuthAccountConfig] 类型
+        site_accounts = self.account_config.site
         results = []
 
         # 尝试 cookies 认证
@@ -1500,6 +1867,34 @@ class CheckIn:
                             results.append((account_label, False, user_info))
                 except Exception as e:
                     print(f"❌ {self.account_name}: GitHub authentication error ({mask_username(github_account.username)}): {e}")
+                    results.append((account_label, False, {"error": str(e)}))
+
+        if site_accounts:
+            for idx, site_account in enumerate(site_accounts):
+                account_label = f"site[{idx}]" if len(site_accounts) > 1 else "site"
+                print(f"\nℹ️ {self.account_name}: Trying site authentication ({mask_username(site_account.username)})")
+                try:
+                    username = site_account.username
+                    password = site_account.password
+                    if not username or not password:
+                        print(f"❌ {self.account_name}: Incomplete site account information")
+                        results.append((account_label, False, {"error": "Incomplete site account information"}))
+                    else:
+                        success, user_info = await self.check_in_with_site(
+                            username,
+                            password,
+                            bypass_cookies,
+                            common_headers,
+                            site_account.mode,
+                        )
+                        if success:
+                            print(f"✅ {self.account_name}: Site authentication successful ({mask_username(site_account.username)})")
+                            results.append((account_label, True, user_info))
+                        else:
+                            print(f"❌ {self.account_name}: Site authentication failed ({mask_username(site_account.username)})")
+                            results.append((account_label, False, user_info))
+                except Exception as e:
+                    print(f"❌ {self.account_name}: Site authentication error ({mask_username(site_account.username)}): {e}")
                     results.append((account_label, False, {"error": str(e)}))
 
         # 尝试 Linux.do 认证（支持多个账号）

--- a/secret-json-generator.html
+++ b/secret-json-generator.html
@@ -396,7 +396,7 @@
     <div class="card" id="panel-ACCOUNTS">
       <span class="step-header">STEP 02 / CONFIGURE ACCOUNTS</span>
       <h2>ACCOUNTS 配置</h2>
-      <p>新增並配置你的簽到帳號。每筆資料至少需提供 Cookies、Linux.do 或 GitHub 其中一種登入方式。</p>
+      <p>新增並配置你的簽到帳號。每筆資料至少需提供 Cookies、站點帳密、Linux.do 或 GitHub 其中一種登入方式。</p>
       
       <div id="accountsList"></div>
       
@@ -570,6 +570,24 @@
           </div>
 
           <div class="col-4">
+            <label>site 模式</label>
+            <select data-k="site_mode">
+              <option value="none">不使用</option>
+              <option value="auto">單一帳號（預設：API 失敗時回退瀏覽器）</option>
+              <option value="api">單一帳號（僅 API）</option>
+              <option value="browser">單一帳號（僅瀏覽器）</option>
+            </select>
+          </div>
+          <div class="col-4">
+            <label>site username</label>
+            <input data-k="site_user" placeholder="site-user">
+          </div>
+          <div class="col-4">
+            <label>site password</label>
+            <input data-k="site_pass" placeholder="site-pass">
+          </div>
+
+          <div class="col-4">
             <label>linux.do 模式</label>
             <select data-k="linux_mode">
               <option value="none">不使用</option>
@@ -712,6 +730,9 @@
         const provider = get("provider");
         const apiUser = get("api_user");
         const cookieSession = get("cookie_session");
+        const siteMode = get("site_mode");
+        const siteUser = get("site_user");
+        const sitePass = get("site_pass");
         const linuxMode = get("linux_mode");
         const linuxUser = get("linux_user");
         const linuxPass = get("linux_pass");
@@ -731,6 +752,16 @@
           }
         }
         if (apiUser) account.api_user = apiUser;
+
+        if (["auto", "api", "browser"].includes(siteMode)) {
+          if (!siteUser || !sitePass) {
+            throw new Error(`第 ${idx + 1} 筆：site 選擇單一帳號時，username/password 必填。`);
+          }
+          account.site = { username: siteUser, password: sitePass };
+          if (siteMode !== "auto") {
+            account.site.mode = siteMode;
+          }
+        }
 
         if (linuxMode === "global") {
           account["linux.do"] = true;
@@ -754,9 +785,9 @@
           account.proxy = { server: proxyServer };
         }
 
-        const hasAuth = Boolean(account.cookies || account["linux.do"] || account.github);
+        const hasAuth = Boolean(account.cookies || account.site || account["linux.do"] || account.github);
         if (!hasAuth) {
-          throw new Error(`第 ${idx + 1} 筆：cookies / linux.do / github 至少需要一種。`);
+          throw new Error(`第 ${idx + 1} 筆：cookies / site / linux.do / github 至少需要一種。`);
         }
 
         if (extraJson) {

--- a/utils/config.py
+++ b/utils/config.py
@@ -211,6 +211,28 @@ class OAuthAccountConfig:
 
 
 @dataclass
+class SiteAccountConfig:
+    """站点账号密码配置"""
+
+    username: str
+    password: str
+    mode: Literal["auto", "api", "browser"] = "auto"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SiteAccountConfig":
+        """从字典创建 SiteAccountConfig"""
+        mode = data.get("mode", "auto")
+        if mode not in ("auto", "api", "browser"):
+            mode = "auto"
+
+        return cls(
+            username=data.get("username", ""),
+            password=data.get("password", ""),
+            mode=mode,
+        )
+
+
+@dataclass
 class AccountConfig:
     """账号配置"""
 
@@ -220,6 +242,7 @@ class AccountConfig:
     name: str | None = None
     linux_do: List["OAuthAccountConfig"] | None = None  # 改为列表类型
     github: List["OAuthAccountConfig"] | None = None  # 改为列表类型
+    site: List["SiteAccountConfig"] | None = None
     proxy: dict | None = None
     extra: dict = field(default_factory=dict)  # 存储额外的配置字段
 
@@ -229,6 +252,7 @@ class AccountConfig:
         data: dict,
         linux_do_accounts: List["OAuthAccountConfig"] | None = None,
         github_accounts: List["OAuthAccountConfig"] | None = None,
+        site_accounts: List["SiteAccountConfig"] | None = None,
     ) -> "AccountConfig":
         """从字典创建 AccountConfig
 
@@ -245,7 +269,7 @@ class AccountConfig:
         proxy = data.get("proxy")
 
         # 提取已知字段
-        known_keys = {"provider", "name", "cookies", "api_user", "linux.do", "github", "proxy"}
+        known_keys = {"provider", "name", "cookies", "api_user", "linux.do", "github", "site", "proxy"}
         # 收集额外的配置字段
         extra = {k: v for k, v in data.items() if k not in known_keys}
 
@@ -256,6 +280,7 @@ class AccountConfig:
             api_user=data.get("api_user", ""),
             linux_do=linux_do_accounts,
             github=github_accounts,
+            site=site_accounts,
             proxy=proxy,
             extra=extra,
         )
@@ -284,6 +309,53 @@ class AppConfig:
     linux_do_accounts: List["OAuthAccountConfig"] = field(default_factory=list)  # 全局 Linux.do 账号列表
     github_accounts: List["OAuthAccountConfig"] = field(default_factory=list)  # 全局 GitHub 账号列表
     global_proxy: Dict | None = None
+
+    @classmethod
+    def _parse_site_config(
+        cls,
+        config_value,
+        account_index: int,
+    ) -> List["SiteAccountConfig"] | None:
+        """解析站点账号密码配置，支持单个账号或多个账号"""
+        if isinstance(config_value, dict):
+            if "username" not in config_value or "password" not in config_value:
+                print(f"❌ Account {account_index + 1} site configuration must contain username and password")
+                return None
+
+            if not config_value["username"] or not config_value["password"]:
+                print(f"❌ Account {account_index + 1} site username and password cannot be empty")
+                return None
+
+            if config_value.get("mode", "auto") not in ("auto", "api", "browser"):
+                print(f"❌ Account {account_index + 1} site mode must be auto, api, or browser")
+                return None
+
+            return [SiteAccountConfig.from_dict(config_value)]
+
+        if isinstance(config_value, list):
+            accounts = []
+            for j, item in enumerate(config_value):
+                if not isinstance(item, dict):
+                    print(f"❌ Account {account_index + 1} site[{j}] must be a dictionary")
+                    return None
+
+                if "username" not in item or "password" not in item:
+                    print(f"❌ Account {account_index + 1} site[{j}] must contain username and password")
+                    return None
+
+                if not item["username"] or not item["password"]:
+                    print(f"❌ Account {account_index + 1} site[{j}] username and password cannot be empty")
+                    return None
+
+                if item.get("mode", "auto") not in ("auto", "api", "browser"):
+                    print(f"❌ Account {account_index + 1} site[{j}] mode must be auto, api, or browser")
+                    return None
+
+                accounts.append(SiteAccountConfig.from_dict(item))
+            return accounts
+
+        print(f"❌ Account {account_index + 1} site configuration must be dict or array")
+        return None
 
     @classmethod
     def load_from_env(
@@ -920,6 +992,7 @@ class AppConfig:
                 # 检查配置键是否存在
                 has_linux_do = "linux.do" in account
                 has_github = "github" in account
+                has_site = "site" in account
                 has_cookies = "cookies" in account
 
                 # 解析 linux.do 配置（支持 bool、单个账号、多个账号）
@@ -948,6 +1021,13 @@ class AppConfig:
                         print(f"⚠️ {account_name} github configuration is invalid, skipping")
                         continue
 
+                site_accounts = None
+                if has_site:
+                    site_accounts = cls._parse_site_config(account["site"], i)
+                    if site_accounts is None:
+                        print(f"⚠️ {account_name} site configuration is invalid, skipping")
+                        continue
+
                 # 验证 cookies 配置
                 valid_cookies = False
                 if has_cookies:
@@ -964,16 +1044,17 @@ class AppConfig:
                 # 检查解析后是否至少有一个有效的认证方式
                 has_valid_linux_do = linux_do_accounts is not None and len(linux_do_accounts) > 0
                 has_valid_github = github_accounts is not None and len(github_accounts) > 0
+                has_valid_site = site_accounts is not None and len(site_accounts) > 0
                 has_valid_cookies = valid_cookies
 
-                if not has_valid_linux_do and not has_valid_github and not has_valid_cookies:
+                if not has_valid_linux_do and not has_valid_github and not has_valid_site and not has_valid_cookies:
                     print(
-                        f"⚠️ {account_name} must have at least one valid authentication method (linux.do, github, or cookies), skipping"
+                        f"⚠️ {account_name} must have at least one valid authentication method (site, linux.do, github, or cookies), skipping"
                     )
                     continue
 
                 # 创建 AccountConfig，传入解析后的 OAuth 账号列表
-                account_config = AccountConfig.from_dict(account, linux_do_accounts, github_accounts)
+                account_config = AccountConfig.from_dict(account, linux_do_accounts, github_accounts, site_accounts)
                 accounts.append(account_config)
 
             return accounts


### PR DESCRIPTION
注：这份PR中的更改是我用GPT生成的。我对代码进行了简单的审阅，并没有发现问题，并且用我自己账号测试了，没有报错，便提交了。

变更内容：新增了site登录方式，使用站点的账号密码进行登录。默认调用登录接口，如果失败则使用浏览器框架输入账号密码秒单进行登录。